### PR TITLE
Version updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 !Gruntfile.js
 !dist/*.js
 node_modules/
+bower_components/

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "author": "Louis Sivillo",
   "name": "angular-file-dnd",
   "description": "AngularJS directive leveraging HTML5 Drag and Drop and the FileReader API",
-  "version": "1.1.0",
+  "version": "1.0.4",
   "main": "dist/angular-file-dnd.min.js",
   "dependencies": {
     "angular": "~1.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-file-dnd",
-  "version": "1.1.0",
+  "version": "1.0.4",
   "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
Moved versions to `1.0.4` to follow up the latest PR for invalidating forms. We realize this should be classified as a patch rather than feature. 

In a normal situation, a change to a model within a form would usually mark the form as dirty, however since this component does not use any input elements, this step is missed. 
